### PR TITLE
fix a bug in _remove_group

### DIFF
--- a/AlphaGo/go.py
+++ b/AlphaGo/go.py
@@ -136,9 +136,9 @@ class GameState(object):
 			self.liberty_counts[gx][gy] = count_merged_libs
 
 	def _remove_group(self, group):
-		"""A private helper function to take a group off the board (due to capture),
-		updating group sets and liberties along the way
-		"""
+	"""A private helper function to take a group off the board (due to capture),
+	updating group sets and liberties along the way
+	"""
 		for (x, y) in group:
 			self.board[x, y] = EMPTY
 		for (x, y) in group:
@@ -150,11 +150,11 @@ class GameState(object):
 				if self.board[nx, ny] == EMPTY:
 					# add empty neighbors of (x,y) to its liberties
 					self.liberty_sets[x][y].add((nx, ny))
-					self.liberty_counts[x][y] += 1
 				else:
 					# add (x,y) to the liberties of its nonempty neighbors
 					self.liberty_sets[nx][ny].add((x, y))
-					self.liberty_counts[nx][ny] += 1
+					for (gx,gy) in self.group_sets[nx][ny]:
+						self.liberty_counts[gx][gy] += 1
 
 	def copy(self):
 		"""get a copy of this Game state


### PR DESCRIPTION
There is a problem in counting the liberties when you remove a group of stone whose size is strictly bigger than 1