### PR TITLE
a bug in _remove_group

### DIFF
--- a/AlphaGo/go.py
+++ b/AlphaGo/go.py
@@ -154,7 +154,7 @@ class GameState(object):
 					# add (x,y) to the liberties of its nonempty neighbors
 					self.liberty_sets[nx][ny].add((x, y))
 					for (gx, gy) in self.group_sets[nx][ny]:
-						self.liberty_counts[gx][gy] += 1
+						self.liberty_counts[gx][gy] = len(self.liberty_sets[nx][ny])
 
 	def copy(self):
 		"""get a copy of this Game state


### PR DESCRIPTION
Sorry, the last code that I pulled has error in line 157.
0-1 0
-1 1-1 #0 empty 1 black -1 white
-1-1 0
in this case, 1 will be removed,then replaced by 0. if self.liberty_counts[gx][gy] += 1 is used, then the white group in the lower left will count the liberty twice, because two stones in that group is adjacent to the stone 1, and I add the liberty twice.