### PR TITLE
The training data needs to be a multiple of the minibatch size

### DIFF
--- a/AlphaGo/training/supervised_policy_trainer.py
+++ b/AlphaGo/training/supervised_policy_trainer.py
@@ -131,7 +131,9 @@ def run_training(cmd_line_args=None):
 	dataset = h5.File(args.train_data)
 	n_total_data = len(dataset["states"])
 	n_train_data = int(args.train_val_test[0] * n_total_data)
-	n_val_data = int(args.train_val_test[1] * n_total_data)
+	# Need to make sure training data is divisible by minibatch size or get warning mentioning accuracy from keras
+	n_train_data = n_train_data - (n_train_data % args.minibatch)
+	n_val_data = n_total_data - n_train_data
 	# n_test_data = n_total_data - (n_train_data + n_val_data)
 
 	if args.verbose:


### PR DESCRIPTION
The training data needs to be a multiple of the minibatch size or you get a warning from keras then mentions possible accuracy loss. I see there is supposed to be an additional dataset... but looked WIP so left alone.