### PR TITLE
Cache features in preprocessing.py

### DIFF
--- a/AlphaGo/preprocessing/caching.py
+++ b/AlphaGo/preprocessing/caching.py
@@ -1,3 +1,6 @@
+import threading
+
+
 class DLLNode(object):
     '''A single node in a doubly-linked list.
     '''
@@ -31,32 +34,38 @@ class DLLNode(object):
 
 class LRUCache(object):
     '''A least-recently used cache. This is a key-value store with a limit on the number of
-    elements that can be stored. When elements are added that would make the size of the cache
-    larger than its limit, the least-recently used key/value pair is deleted.
+       elements that can be stored. When elements are added that would make the size of the cache
+       larger than its limit, the least-recently used key/value pair is deleted.
 
-    Both writing (using put) and reading (using get) count as 'using' a key/value pair.
+       Both writing (using put) and reading (using get) count as 'using' a key/value pair.
 
-    The implementation uses a doubly-linked list to keep track of the order in which elements were
-    accessed. self.sentinel.next is always the most-recently-used, and self.sentinel.prev is always
-    the least-recently used. self.lookup is a dictionary mapping from keys to DLL nodes. Between
-    hash table lookups and DLL operations, all updates are done in constant-time (amortized).
+       The implementation uses a doubly-linked list to keep track of the order in which elements
+       were accessed. self.sentinel.next is always the most-recently-used, and self.sentinel.prev is
+       always the least-recently used. self.lookup is a dictionary mapping from keys to DLL nodes.
+       Between hash table lookups and DLL operations, all updates are done in constant-time
+       (amortized).
+
+       Public functions are thread-safe (i.e. get() and put()), but private functions are not (i.e.
+       _refresh() and _delete())
     '''
 
-    __slots__ = ['sentinel', 'lookup', 'max_size']
+    __slots__ = ['sentinel', 'lookup', 'max_size', 'lock']
 
     def __init__(self, max_size=1e5):
         self.sentinel = DLLNode(None, None)
         self.lookup = {}
         self.max_size = max_size
+        self.lock = threading.Lock()
 
     def get(self, key):
         '''If 'key' is in the cache, return a tuple (True, value). Otherwise, return (False, None).
         '''
-        if key in self.lookup:
-            self._refresh(key)
-            return True, self.lookup[key].value
-        else:
-            return False, None
+        with self.lock:
+            if key in self.lookup:
+                self._refresh(key)
+                return True, self.lookup[key].value
+            else:
+                return False, None
 
     def _refresh(self, key):
         '''Move keyed item to the front of the DLL. key must be in the cache.
@@ -69,21 +78,22 @@ class LRUCache(object):
         '''Put value into cache or refresh existing value. If the cache size exceeds max_size, the
         least recently used key/value pair is removed.
         '''
-        if key in self.lookup:
-            self._refresh(key)
-            self.lookup[key].value = value
-        else:
-            # Add this key/value pair to the cache.
-            node = DLLNode(key, value)
-            self.sentinel.insert_after(node)
-            self.lookup[key] = node
-            # Keep size below max_size.
-            if len(self.lookup) > self.max_size:
-                # Delete least recently used key/value pair.
-                lru_key = self.sentinel.prev.key
-                self.delete(lru_key)
+        with self.lock:
+            if key in self.lookup:
+                self._refresh(key)
+                self.lookup[key].value = value
+            else:
+                # Add this key/value pair to the cache.
+                node = DLLNode(key, value)
+                self.sentinel.insert_after(node)
+                self.lookup[key] = node
+                # Keep size below max_size.
+                if len(self.lookup) > self.max_size:
+                    # Delete least recently used key/value pair.
+                    lru_key = self.sentinel.prev.key
+                    self._delete(lru_key)
 
-    def delete(self, key):
+    def _delete(self, key):
         '''Remove an item from the cache. No error is raised if key is not in the cache.
         '''
         if key in self.lookup:

--- a/AlphaGo/preprocessing/caching.py
+++ b/AlphaGo/preprocessing/caching.py
@@ -1,0 +1,109 @@
+class DLLNode(object):
+    '''A single node in a doubly-linked list.
+    '''
+
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+        self.next = self
+        self.prev = self
+
+    def insert_after(self, other):
+        self.next.prev = other
+        other.next = self.next
+        self.next = other
+        other.prev = self
+
+    def insert_before(self, other):
+        self.prev.next = other
+        other.prev = self.prev
+        self.prev = other
+        other.next = self
+
+    def splice(self):
+        self.prev.next = self.next
+        self.next.prev = self.prev
+        self.next = self
+        self.prev = self
+
+
+class LRUCache(object):
+    '''A least-recently used cache. This is a key-value store with a limit on the number of
+    elements that can be stored. When elements are added that would make the size of the cache
+    larger than its limit, the least-recently used key/value pair is deleted.
+
+    Both writing (using put) and reading (using get) count as 'using' a key/value pair.
+
+    The implementation uses a doubly-linked list to keep track of the order in which elements were
+    accessed. self.sentinel.next is always the most-recently-used, and self.sentinel.prev is always
+    the least-recently used. self.lookup is a dictionary mapping from keys to DLL nodes. Between
+    hash table lookups and DLL operations, all updates are done in constant-time (amortized).
+    '''
+
+    def __init__(self, max_size=1e5):
+        self.sentinel = DLLNode(None, None)
+        self.lookup = {}
+        self.max_size = max_size
+        self.size = 0
+
+    def get(self, key):
+        '''If 'key' is in the cache, return a tuple (True, value). Otherwise, return (False, None).
+        '''
+        if key in self.lookup:
+            self._refresh(key)
+            return True, self.lookup[key].value
+        else:
+            return False, None
+
+    def _refresh(self, key):
+        '''Move keyed item to the front of the DLL. key must be in the cache.
+        '''
+        node = self.lookup[key]
+        node.splice()
+        self.sentinel.insert_after(node)
+
+    def put(self, key, value):
+        '''Put value into cache or refresh existing value. If the cache size exceeds max_size, the
+        least recently used key/value pair is removed.
+        '''
+        if key in self.lookup:
+            self._refresh(key)
+            self.lookup[key].value = value
+        else:
+            # Add this key/value pair to the cache.
+            node = DLLNode(key, value)
+            self.sentinel.insert_after(node)
+            self.lookup[key] = node
+            # Keep size below max_size.
+            if self.size == self.max_size:
+                # Delete least recently used key/value pair.
+                lru_key = self.sentinel.prev.key
+                self.delete(lru_key)
+            self.size += 1
+
+    def delete(self, key):
+        '''Remove an item from the cache. No error is raised if key is not in the cache.
+        '''
+        if key in self.lookup:
+            self.lookup[key].splice()
+            del self.lookup[key]
+            self.size -= 1
+
+
+def lru_cache(max_size, key_fn=None):
+    '''Decorator that wraps a function in an LRU cache. If no key_fn is given, the function's args
+    are used as the cache key (they must be hashable).
+    '''
+
+    cache = LRUCache(max_size=max_size)
+
+    def lru_decorator(fn):
+        def lookup_or_execute(*args, **kwargs):
+            key = tuple(args) if key_fn is None else key_fn(*args)
+            is_cached, value = cache.get(key)
+            if not is_cached:
+                value = fn(*args, **kwargs)
+                cache.put(key, value)
+            return value
+        return lookup_or_execute
+    return lru_decorator

--- a/AlphaGo/preprocessing/caching.py
+++ b/AlphaGo/preprocessing/caching.py
@@ -2,6 +2,8 @@ class DLLNode(object):
     '''A single node in a doubly-linked list.
     '''
 
+    __slots__ = ['key', 'value', 'next', 'prev']
+
     def __init__(self, key, value):
         self.key = key
         self.value = value
@@ -40,11 +42,12 @@ class LRUCache(object):
     hash table lookups and DLL operations, all updates are done in constant-time (amortized).
     '''
 
+    __slots__ = ['sentinel', 'lookup', 'max_size']
+
     def __init__(self, max_size=1e5):
         self.sentinel = DLLNode(None, None)
         self.lookup = {}
         self.max_size = max_size
-        self.size = 0
 
     def get(self, key):
         '''If 'key' is in the cache, return a tuple (True, value). Otherwise, return (False, None).
@@ -75,11 +78,10 @@ class LRUCache(object):
             self.sentinel.insert_after(node)
             self.lookup[key] = node
             # Keep size below max_size.
-            if self.size == self.max_size:
+            if len(self.lookup) > self.max_size:
                 # Delete least recently used key/value pair.
                 lru_key = self.sentinel.prev.key
                 self.delete(lru_key)
-            self.size += 1
 
     def delete(self, key):
         '''Remove an item from the cache. No error is raised if key is not in the cache.
@@ -87,7 +89,6 @@ class LRUCache(object):
         if key in self.lookup:
             self.lookup[key].splice()
             del self.lookup[key]
-            self.size -= 1
 
 
 def lru_cache(max_size, key_fn=None):

--- a/AlphaGo/preprocessing/preprocessing.py
+++ b/AlphaGo/preprocessing/preprocessing.py
@@ -45,6 +45,8 @@ def get_board(state):
     return planes
 
 
+# TODO - this is only approximate since history prior to the last n moves may affect whether a given
+# stone is still alive. Need to test whether this causes problems.
 @lru_cache(max_size=_CACHE_SIZE, key_fn=board_and_n_history)
 def get_turns_since(state, maximum=8):
     """A feature encoding the age of the stone at each location up to 'maximum'

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,83 @@
+from AlphaGo.preprocessing.caching import LRUCache, lru_cache
+import unittest
+
+
+class TestLRUCache(unittest.TestCase):
+
+    def setUp(self):
+        self.cache = LRUCache(max_size=3)
+
+    def testGetPutDelete(self):
+        self.assertEqual(self.cache.size, 0)
+        self.cache.put('a', 1)
+        self.cache.put('b', 2)
+        self.cache.put('c', 3)
+        self.assertEqual(self.cache.size, 3)
+
+        # 'c' should be cached and most-recently-used.
+        # Current cache order: a b c
+        is_cached, value = self.cache.get('c')
+        self.assertTrue(is_cached)
+        self.assertEqual(value, 3)
+
+        # A 4th insertion should evict 'a', which is least-recently used.
+        # Current cache order: a b c
+        self.cache.put('d', 4)
+        # Current cache order: b c d
+        self.assertEqual(self.cache.size, 3)
+        is_cached, value = self.cache.get('a')
+        self.assertFalse(is_cached)
+        self.assertIsNone(value)
+        self.assertEqual(self.cache.size, 3)
+
+        # 'b' is LRU. After querying it, 'c' should be LRU.
+        # Current cache order: b c d
+        self.cache.get('b')
+        # Current cache order: c d b
+        self.cache.put('e', 5)
+        # Current cache order: d b e
+        is_cached, value = self.cache.get('c')
+        self.assertFalse(is_cached)
+        self.assertEqual(self.cache.size, 3)
+
+        # test deletion.
+        self.cache.delete('d')
+        # Current cache order: b e
+        self.assertEqual(self.cache.size, 2)
+        is_cached, value = self.cache.get('d')
+        self.assertFalse(is_cached)
+
+
+class TestDecorator(unittest.TestCase):
+
+    def testNoKeyFn(self):
+        @lru_cache(max_size=3)
+        def fn(x, y=0):
+            return x + y
+        self.assertEqual(fn(1), 1)
+        self.assertEqual(fn(2), 2)
+        # fn should return the cached value here
+        self.assertEqual(fn(1, y=100), 1)
+        self.assertEqual(fn(2), 2)
+        self.assertEqual(fn(3), 3)
+        self.assertEqual(fn(4), 4)
+        # key '1' is expired. Value will be recomputed.
+        self.assertEqual(fn(1, y=100), 101)
+
+    def testKeyFn(self):
+        # Demonstrate key functions using absolute value of input as key.
+        @lru_cache(max_size=3, key_fn=abs)
+        def fn(x):
+            return x + 1
+        self.assertEqual(fn(1), 2)
+        self.assertEqual(fn(2), 3)
+        # fn should return the cached value here
+        self.assertEqual(fn(-1), 2)
+        self.assertEqual(fn(2), 3)
+        self.assertEqual(fn(3), 4)
+        self.assertEqual(fn(4), 5)
+        # key '1' is expired. Value will be recomputed.
+        self.assertEqual(fn(-1), 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -79,5 +79,6 @@ class TestDecorator(unittest.TestCase):
         # key '1' is expired. Value will be recomputed.
         self.assertEqual(fn(-1), 0)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -8,11 +8,11 @@ class TestLRUCache(unittest.TestCase):
         self.cache = LRUCache(max_size=3)
 
     def testGetPutDelete(self):
-        self.assertEqual(self.cache.size, 0)
+        self.assertEqual(len(self.cache.lookup), 0)
         self.cache.put('a', 1)
         self.cache.put('b', 2)
         self.cache.put('c', 3)
-        self.assertEqual(self.cache.size, 3)
+        self.assertEqual(len(self.cache.lookup), 3)
 
         # 'c' should be cached and most-recently-used.
         # Current cache order: a b c
@@ -24,11 +24,11 @@ class TestLRUCache(unittest.TestCase):
         # Current cache order: a b c
         self.cache.put('d', 4)
         # Current cache order: b c d
-        self.assertEqual(self.cache.size, 3)
+        self.assertEqual(len(self.cache.lookup), 3)
         is_cached, value = self.cache.get('a')
         self.assertFalse(is_cached)
         self.assertIsNone(value)
-        self.assertEqual(self.cache.size, 3)
+        self.assertEqual(len(self.cache.lookup), 3)
 
         # 'b' is LRU. After querying it, 'c' should be LRU.
         # Current cache order: b c d
@@ -38,12 +38,12 @@ class TestLRUCache(unittest.TestCase):
         # Current cache order: d b e
         is_cached, value = self.cache.get('c')
         self.assertFalse(is_cached)
-        self.assertEqual(self.cache.size, 3)
+        self.assertEqual(len(self.cache.lookup), 3)
 
         # test deletion.
         self.cache.delete('d')
         # Current cache order: b e
-        self.assertEqual(self.cache.size, 2)
+        self.assertEqual(len(self.cache.lookup), 2)
         is_cached, value = self.cache.get('d')
         self.assertFalse(is_cached)
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -41,7 +41,7 @@ class TestLRUCache(unittest.TestCase):
         self.assertEqual(len(self.cache.lookup), 3)
 
         # test deletion.
-        self.cache.delete('d')
+        self.cache._delete('d')
         # Current cache order: b e
         self.assertEqual(len(self.cache.lookup), 2)
         is_cached, value = self.cache.get('d')


### PR DESCRIPTION
This PR includes a generic LRU Cache implementation and applies it to feature preprocessing. When there is a cache hit, an existing numpy array is returned - no new allocation or extra processing is needed. Cache lookups and updates are all `O(1)` time on average.

This is useful for any repeated playouts using the same policy (RL policy, RL value, MCTS).

Closes #160.
