### PR TITLE
Overriding Keras defaults to use theano-style tensor dimensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ install:
 # run flake8 and unit tests
 script:
     - flake8
-    - THEANO_FLAGS="gcc.cxxflags='-march=core2'" python -m unittest discover
+    - THEANO_FLAGS="gcc.cxxflags='-march=core2'" KERAS_BACKEND=theano python -m unittest discover

--- a/AlphaGo/preprocessing/preprocessing.py
+++ b/AlphaGo/preprocessing/preprocessing.py
@@ -1,5 +1,10 @@
 import numpy as np
 import AlphaGo.go as go
+import keras.backend as K
+
+# This file is used anywhere that neural net features are used; setting the keras dimension ordering
+# here makes it universal to the project.
+K.set_image_dim_ordering('th')
 
 ##
 # individual feature functions (state --> tensor) begin here


### PR DESCRIPTION
This is a patch for compatibility with keras 1.1.2, which now has tensorflow as the default. The longer-term solution will be to switch this project to use the tensorflow standards.

Note: RL test is still failing, but this fixes all other travis failures