### PR TITLE
Fixed SL/RL saving of command line args

### DIFF
--- a/AlphaGo/training/reinforcement_policy_trainer.py
+++ b/AlphaGo/training/reinforcement_policy_trainer.py
@@ -175,7 +175,8 @@ def run_training(cmd_line_args=None):
             metadata = json.load(f)
 
     # Append args of current run to history of full command args.
-    metadata["cmd_line_args"] = metadata.get("cmd_line_args", []).append(vars(args))
+    metadata["cmd_line_args"] = metadata.get("cmd_line_args", [])
+    metadata["cmd_line_args"].append(vars(args))
 
     def save_metadata():
         with open(os.path.join(args.out_directory, "metadata.json"), "w") as f:

--- a/AlphaGo/training/supervised_policy_trainer.py
+++ b/AlphaGo/training/supervised_policy_trainer.py
@@ -201,8 +201,8 @@ def run_training(cmd_line_args=None):
     meta_writer.metadata["model_file"] = args.model
     # Record all command line args in a list so that all args are recorded even
     # when training is stopped and resumed.
-    meta_writer.metadata["cmd_line_args"] \
-        = meta_writer.metadata.get("cmd_line_args", []).append(vars(args))
+    meta_writer.metadata["cmd_line_args"] = meta_writer.metadata.get("cmd_line_args", [])
+    meta_writer.metadata["cmd_line_args"].append(vars(args))
 
     # create ModelCheckpoint to save weights every epoch
     checkpoint_template = os.path.join(args.out_directory, "weights.{epoch:05d}.hdf5")


### PR DESCRIPTION
`cmd_line_args` is currently always getting saved as `null` in my `metadata.json` (did this work for you?).

This is because we're currently assigning the return value of `[].append(something)`, which is `None`. I'm also unable to resume training from previous weights because of this (same error MaMiFreak had here: https://github.com/Rochester-NRT/RocAlphaGo/issues/187)

```
> python -m AlphaGo.training.supervised_policy_trainer model.json dataset.hdf5 results/ --epochs 100 --minibatch 32 --learning-rate 0.01 --weights weights.00099.hdf5
AttributeError: 'NoneType' object has no attribute 'append'
# caused by reading cmd_line_args as null second time around
```