### PR TITLE
Policy RL sets learning rate using `K.set_value`. Fixes slowdown.

### DIFF
--- a/AlphaGo/training/reinforcement_policy_trainer.py
+++ b/AlphaGo/training/reinforcement_policy_trainer.py
@@ -19,7 +19,7 @@ def _make_training_pair(st, mv, preprocessor):
     return (st_tensor, mv_tensor)
 
 
-def run_n_games(optimizer, learner, opponent, num_games, mock_states=[]):
+def run_n_games(optimizer, lr, learner, opponent, num_games, mock_states=[]):
     '''Run num_games games to completion, keeping track of each position and move of the learner.
 
     (Note: learning cannot happen until all games have completed)
@@ -78,7 +78,7 @@ def run_n_games(optimizer, learner, opponent, num_games, mock_states=[]):
     # Train on each game's results, setting the learning rate negative to 'unlearn' positions from
     # games where the learner lost.
     for (st_tensor, mv_tensor, won) in zip(state_tensors, move_tensors, learner_won):
-        optimizer.lr = K.abs(optimizer.lr) * (+1 if won else -1)
+        K.set_value(optimizer.lr, abs(lr) * (+1 if won else -1))
         learner_net.train_on_batch(np.concatenate(st_tensor, axis=0),
                                    np.concatenate(mv_tensor, axis=0))
 
@@ -208,7 +208,7 @@ def run_training(cmd_line_args=None):
 
         # Run games (and learn from results). Keep track of the win ratio vs each opponent over
         # time.
-        win_ratio = run_n_games(optimizer, player, opponent, args.game_batch)
+        win_ratio = run_n_games(optimizer, args.learning_rate, player, opponent, args.game_batch)
         metadata["win_ratio"][player_weights] = (opp_weights, win_ratio)
 
         # Save intermediate models.

--- a/tests/test_reinforcement_policy_trainer.py
+++ b/tests/test_reinforcement_policy_trainer.py
@@ -102,7 +102,7 @@ class TestReinforcementPolicyTrainer(unittest.TestCase):
             opponent = MockPlayer(policy2, game)
 
             # Run RL training
-            run_n_games(optimizer, learner, opponent, 2, mock_states=states)
+            run_n_games(optimizer, 0.001, learner, opponent, 2, mock_states=states)
 
             return policy1.model.get_weights()
 
@@ -145,12 +145,12 @@ class TestReinforcementPolicyTrainer(unittest.TestCase):
                                                         'minimodel_policy.json'))
             learner = MockPlayer(policy1, game)
             opponent = MockPlayer(policy2, game)
-            optimizer = SGD()
+            optimizer = SGD(lr=0.001)
             init_weights = policy1.model.get_weights()
             policy1.model.compile(loss=log_loss, optimizer=optimizer)
 
             # Run RL training
-            run_n_games(optimizer, learner, opponent, 2)
+            run_n_games(optimizer, 0.001, learner, opponent, 2)
 
             # Get new weights for comparison
             trained_weights = policy1.model.get_weights()
@@ -174,7 +174,7 @@ class TestReinforcementPolicyTrainer(unittest.TestCase):
                                                         'minimodel_policy.json'))
             learner = MockPlayer(policy1, game)
             opponent = MockPlayer(policy2, game)
-            optimizer = SGD()
+            optimizer = SGD(lr=0.001)
             policy1.model.compile(loss=log_loss, optimizer=optimizer)
 
             # Get initial (before learning) move probabilities for all moves made by black
@@ -182,7 +182,7 @@ class TestReinforcementPolicyTrainer(unittest.TestCase):
             init_probs = [prob for (mv, prob) in init_move_probs]
 
             # Run RL training
-            run_n_games(optimizer, learner, opponent, 1, mock_states=win_state)
+            run_n_games(optimizer, 0.001, learner, opponent, 1, mock_states=win_state)
 
             # Get new move probabilities for black's moves having finished 1 round of training
             new_move_probs = get_sgf_move_probs(game, policy1, go.BLACK)
@@ -205,7 +205,7 @@ class TestReinforcementPolicyTrainer(unittest.TestCase):
                                                         'minimodel_policy.json'))
             learner = MockPlayer(policy1, game)
             opponent = MockPlayer(policy2, game)
-            optimizer = SGD()
+            optimizer = SGD(lr=0.001)
             policy1.model.compile(loss=log_loss, optimizer=optimizer)
 
             # Get initial (before learning) move probabilities for all moves made by black
@@ -213,7 +213,7 @@ class TestReinforcementPolicyTrainer(unittest.TestCase):
             init_probs = [prob for (mv, prob) in init_move_probs]
 
             # Run RL training
-            run_n_games(optimizer, learner, opponent, 1, mock_states=lose_state)
+            run_n_games(optimizer, 0.001, learner, opponent, 1, mock_states=lose_state)
 
             # Get new move probabilities for black's moves having finished 1 round of training
             new_move_probs = get_sgf_move_probs(game, policy1, go.BLACK)


### PR DESCRIPTION
Previously, `optimizer.lr = K.abs(optimizer.lr) * ...` added another call to `K.abs()` in the computation graph each iteration, slowing down training as time went on.